### PR TITLE
Fixed to allow from 3 to 4 managers in between without reporting

### DIFF
--- a/src/main/java/com/bigcompany/employees/model/EmployeeAnalysisResult.java
+++ b/src/main/java/com/bigcompany/employees/model/EmployeeAnalysisResult.java
@@ -93,6 +93,7 @@ public class EmployeeAnalysisResult {
      */
     private void analyzeReportLine() {
         int levelDifference = level - maxLevel;
+        levelDifference--;
         if (levelDifference > 0) {
             String obs = String.format(
                     "Employee %d has a reporting line too big. Excess Levels: %d",

--- a/src/test/java/com/bigcompany/employees/model/EmployeeAnalysisResultTest.java
+++ b/src/test/java/com/bigcompany/employees/model/EmployeeAnalysisResultTest.java
@@ -151,7 +151,7 @@ public class EmployeeAnalysisResultTest {
         setUpNoManagerBigReportLineCase();
         assertFalse(result.getObservations().isEmpty());
         
-        String obs = "Employee 50 has a reporting line too big. Excess Levels: 2";
+        String obs = "Employee 50 has a reporting line too big. Excess Levels: 1";
         assertEquals(obs, result.getObservations().getFirst());
     }
     

--- a/src/test/java/com/bigcompany/employees/service/impl/EmployeeServiceTest.java
+++ b/src/test/java/com/bigcompany/employees/service/impl/EmployeeServiceTest.java
@@ -22,7 +22,7 @@ public class EmployeeServiceTest {
         List<String> observations = employeeService.observationsList;
 
         assertFalse(observations.isEmpty(), "Results should not be empty");
-        assertTrue(observations.contains("Employee 407 has a reporting line too big. Excess Levels: 4"), "Results should contain the analysis");
+        assertTrue(observations.contains("Employee 407 has a reporting line too big. Excess Levels: 3"), "Results should contain the analysis");
     }
 
     @Test
@@ -43,8 +43,11 @@ public class EmployeeServiceTest {
         assertFalse(observations.isEmpty(), "Results should not be empty");
 
         // Checking report line obs
-        assertTrue(observations.contains("Employee 407 has a reporting line too big. Excess Levels: 4"), "Results should contain the analysis");
-        assertTrue(observations.contains("Employee 406 has a reporting line too big. Excess Levels: 3"), "Results should contain the analysis");
+        assertTrue(observations.contains("Employee 407 has a reporting line too big. Excess Levels: 3"), "Results should contain the analysis");
+        assertTrue(observations.contains("Employee 406 has a reporting line too big. Excess Levels: 2"), "Results should contain the analysis");
+        assertTrue(observations.contains("Employee 405 has a reporting line too big. Excess Levels: 1"), "Results should contain the analysis");
+        assertFalse(observations.contains("Employee 404 has a reporting line too big. Excess Levels: 0"), "Results not should contain this wrong analysis");
+        assertFalse(observations.contains("Employee 404 has a reporting line too big. Excess Levels: 1"), "Results not should contain this wrong analysis");
         assertFalse(observations.contains("Employee 403 has a reporting line too big. Excess Levels: 0"), "Results not should contain this wrong analysis");
         
         // Checking salary obs


### PR DESCRIPTION
When reading the requirements again, just realized that there is no need to report when employee itself is on the 4th level as it still allowed. Fixed to only report when employee is on 5th level, which means that there 4 in between.